### PR TITLE
Add issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/talk-lite.md
+++ b/.github/ISSUE_TEMPLATE/talk-lite.md
@@ -1,0 +1,32 @@
+---
+name: Tech Talks Lite
+about: A collection of 10–20 minute talks
+title: 'Tech Talks Lite #[index]'
+labels: 'tech talk lite'
+assignees: ''
+
+---
+
+- [Presenter 1 GitHub username] **[Talk title]**
+
+  A short description of the talk goes here. What kinds of things will we learn from this talk?
+  
+- [Presenter 2 GitHub username] **[Talk title]**
+
+  A short description of the talk goes here. What kinds of things will we learn from this talk?
+
+- [Presenter 3 GitHub username] **[Talk title]**
+
+  A short description of the talk goes here. What kinds of things will we learn from this talk?
+  
+- [Presenter 4 GitHub username] **[Talk title]**
+
+  A short description of the talk goes here. What kinds of things will we learn from this talk?
+
+- MC: [The MC’s GitHub username]
+
+## Todo for the MC:
+
+- [ ] Secure Zoom Pro Account.
+- [ ] Enable phone-in option for those using FedRelay.
+- [ ] Upload video.

--- a/.github/ISSUE_TEMPLATE/talk.md
+++ b/.github/ISSUE_TEMPLATE/talk.md
@@ -1,0 +1,19 @@
+---
+name: Full-length tech talk
+about: Submit a talk that will take 30–50 minutes to present
+title: 'Tech Talk: [Your Title Here]'
+labels: 'tech talk'
+assignees: ''
+
+---
+
+A short description of your talk goes here. What kinds of things will we learn from this talk?
+
+- Presenter: [The presenter’s GitHub username]
+- MC: [The MC’s GitHub username]
+
+## Todo for the MC:
+
+- [ ] Secure Zoom Pro Account.
+- [ ] Enable phone-in option for those using FedRelay.
+- [ ] Upload video.


### PR DESCRIPTION
To close #32, this PR adds two issue templates — one for a Tech Talk and one for Tech Talks Lite. I just based the formatting off of what we seem to be already doing. 