### PR TITLE
Update README.md and Queue.md to reflect current practice.

### DIFF
--- a/.github/ISSUE_TEMPLATE/talk-lite.md
+++ b/.github/ISSUE_TEMPLATE/talk-lite.md
@@ -27,6 +27,9 @@ assignees: ''
 
 ## Todo for the MC:
 
-- [ ] Secure Zoom Pro Account.
+- [ ] Secure Zoom Pro Account (done via #admins-zoom on Slack, typically on the morning of the talk or the day before the talk).
+- [ ] Update the 18F Events calendar entry for this event to add the talk details.
+- [ ] Ask the parties responsible for the Engineering Chapter newletter for that week to add details about the talk(s) to the newsletter.
+- [ ] Announce the talk(s) in #dev on Slack in the morning, and follow up with a reminder just before they're about to begin.
 - [ ] Enable phone-in option for those using FedRelay.
 - [ ] Upload video.

--- a/.github/ISSUE_TEMPLATE/talk.md
+++ b/.github/ISSUE_TEMPLATE/talk.md
@@ -14,6 +14,9 @@ A short description of your talk goes here. What kinds of things will we learn f
 
 ## Todo for the MC:
 
-- [ ] Secure Zoom Pro Account.
+- [ ] Secure Zoom Pro Account (done via #admins-zoom on Slack, typically on the morning of the talk or the day before the talk).
+- [ ] Update the 18F Events calendar entry for this talk to add the talk details.
+- [ ] Ask the parties responsible for the Engineering Chapter newletter for that week to add details about the talk(s) to the newsletter.
+- [ ] Announce the talk(s) in #dev on Slack in the morning, and follow up with a reminder just before they're about to begin.
 - [ ] Enable phone-in option for those using FedRelay.
 - [ ] Upload video.

--- a/Queue.md
+++ b/Queue.md
@@ -1,13 +1,19 @@
-# 18F Monthly Tech Talks
+# 18F Engineering Chapter Tech Talks
 
 ## Submitting a talk
-Submit an issue in this repo, or talk to us on Slack.
+Submit an issue in this repo, or talk to us on Slack (#tech-talks).
 
 ## How to attend
-See the 18F-Developers calendar in Google. They are held on the fourth Monday of each month.
+See the 18F Events calendar. Talks are on Mondays, generally happen twice per month, and generally alternate between a longer talk (30–45 minutes) and a set of 2–4 shorter (10–15 minutes) talks.
 
 ## Schedule
+See https://github.com/18F/tech-talks/issues for upcoming talks.
 
+# Archive
+
+This archive is incomplete, and we need a definitive location for past talk materials.
+
+## Videos coming soon
 **13 Aug 2018**
 - Logging on login.gov - Justin Grevich (45 mins)
 
@@ -23,9 +29,6 @@ See the 18F-Developers calendar in Google. They are held on the fourth Monday of
 **Unscheduled** Please don't add talks here. Pick a time slot above instead.
 * Making Meetings Not Suck (Your Time Away) - Fureigh (30 mins)
 
-
-# Archive
-## Videos coming soon
 **08/28/17**
 - Building a time-keeping tool in Rust - Roger (45 mins) ([Slides](https://gist.github.com/rogeruiz/9db97307216a6f3ef31b7fc1e9ba1602))
 - Detecting Tampered Data - DKP (30 mins)

--- a/Queue.md
+++ b/Queue.md
@@ -4,7 +4,7 @@
 Submit an issue in this repo, or talk to us on Slack (#tech-talks).
 
 ## How to attend
-See the 18F Events calendar. Talks are on Mondays, generally happen twice per month, and generally alternate between a longer talk (30–45 minutes) and a set of 2–4 shorter (10–15 minutes) talks.
+See the 18F Events calendar. Talks are on the first and third Wednesdays each month, and generally alternate between a longer talk (30–45 minutes) and a set of 2–4 shorter (10–15 minutes) talks.
 
 ## Schedule
 See https://github.com/18F/tech-talks/issues for upcoming talks.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ This repository is a place to store the related materials, so they:
 
 ## How to use
 
-If you're an 18F staffer and would like to attend the talks, ask in #dev to be added to the invite.
+If you're an 18F staffer and would like to attend the talks, ask in #dev to be added to the invite (or find it on the 18F Events calendar).
 
-If you're an 18F staffer who is giving a tech talk, please create a talk-specific folder and put your materials there. Whatever you have--code samples, links, slides, video--we'll take it!
+If you're an 18F staffer who is giving a tech talk, please create a talk-specific folder and put your materials there. Whatever you have—code samples, links, slides, video—we'll take it!
 
-If you're an 18F staffer who would like to give a talk, [add yourself to the queue](https://github.com/18F/tech-talks/edit/master/Queue.md).
+If you're an 18F staffer who would like to give a talk, please contact us in #tech-talks on Slack or add an issue: https://github.com/18F/tech-talks/issues
 
 If you're not an 18F staffer but want to see what people are talking about, poke around. These are quick, introductory talks; thus there may not be extensive documentation, but there might be something to pique your interest.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 18F has a running series of tech talks: short, internal talks where we share our favorite technology and project information with one another.
 
+Currently we have longer talks on the first Wednesday of every month, and a collection of shorter talks on the third Wednesday.
+
 This repository is a place to store the related materials, so they:
 * aren't lost to the sands of time or Slack, and
 * can be useful to others.
@@ -20,7 +22,7 @@ If you're not an 18F staffer but want to see what people are talking about, poke
 
 Q. As a presenter, how do I tock this time?
 
-A. Training / Prof Dev - Non Billable
+A. `968 - 18F / Non-Billable`.
 
 ## Public domain
 


### PR DESCRIPTION
Long overdue, but
Now reflects reality
And should for a while.

Points people in the direction of #tech-talks for suggesting talks and deprecates using Queue.md for that purpose.